### PR TITLE
[Fix] 컬럼 이동 후 컬럼 생성 시 position 문제 수정

### DIFF
--- a/src/main/java/com/sparta/hotsixproject/side/service/Impl/SideCustomServiceImpl.java
+++ b/src/main/java/com/sparta/hotsixproject/side/service/Impl/SideCustomServiceImpl.java
@@ -31,7 +31,8 @@ public class SideCustomServiceImpl implements SideCustomService {
         checkBoardMember(user, board);
 
         // position => 1024씩 증가
-        int position = (board.getSideList().size() != 0) ? (board.getSideList().size() + 1) * 1024 : 1024;
+        List<Side> sortedSideList = sideRepository.findAllByBoardIdOrderBySidePositionAsc(board.getId());
+        int position = (sortedSideList.size() != 0) ? sortedSideList.get((sortedSideList.size() - 1)).getPosition() + 1024 : 1024;
         Side side = new Side(requestDto.getName(), position, board);
         sideRepository.save(side);
         return new SideResponseDto(side);
@@ -87,7 +88,6 @@ public class SideCustomServiceImpl implements SideCustomService {
                 .map(SideResponseDto::new)
                 .collect(Collectors.toList());
     }
-
 
 
     @Override


### PR DESCRIPTION
![image](https://github.com/spring-b-hotsix/hotsix-project/assets/119802267/3691cefe-b0c3-4fbc-afe1-f615b601f50b)

#### 변경 전
```java
/* SideCustomServiceImpl.createSide() */

int position = (board.getSideList().size() != 0) ? (board.getSideList().size() + 1) * 1024 : 1024;
```

#### 변경 후
오름차순으로 정렬된 `sortedSideList`에서 `가장 큰 값 + 1024`한 만큼의 값으로 설정.
```java
/* SideCustomServiceImpl.createSide() */

List<Side> sortedSideList = sideRepository.findAllByBoardIdOrderBySidePositionAsc(board.getId());
int position = (sortedSideList.size() != 0) ? sortedSideList.get((sortedSideList.size() - 1)).getPosition() + 1024 : 1024;
```