### PR TITLE
Feature/78/alram

### DIFF
--- a/src/main/generated/com/sparta/hotsixproject/board/entity/QBoard.java
+++ b/src/main/generated/com/sparta/hotsixproject/board/entity/QBoard.java
@@ -34,8 +34,6 @@ public class QBoard extends EntityPathBase<Board> {
 
     public final StringPath name = createString("name");
 
-    public final ListPath<com.sparta.hotsixproject.notification.entity.Notification, com.sparta.hotsixproject.notification.entity.QNotification> notificationList = this.<com.sparta.hotsixproject.notification.entity.Notification, com.sparta.hotsixproject.notification.entity.QNotification>createList("notificationList", com.sparta.hotsixproject.notification.entity.Notification.class, com.sparta.hotsixproject.notification.entity.QNotification.class, PathInits.DIRECT2);
-
     public final ListPath<com.sparta.hotsixproject.side.entity.Side, com.sparta.hotsixproject.side.entity.QSide> sideList = this.<com.sparta.hotsixproject.side.entity.Side, com.sparta.hotsixproject.side.entity.QSide>createList("sideList", com.sparta.hotsixproject.side.entity.Side.class, com.sparta.hotsixproject.side.entity.QSide.class, PathInits.DIRECT2);
 
     public final com.sparta.hotsixproject.user.entity.QUser user;

--- a/src/main/generated/com/sparta/hotsixproject/board/entity/QBoard.java
+++ b/src/main/generated/com/sparta/hotsixproject/board/entity/QBoard.java
@@ -34,6 +34,8 @@ public class QBoard extends EntityPathBase<Board> {
 
     public final StringPath name = createString("name");
 
+    public final ListPath<com.sparta.hotsixproject.notification.entity.Notification, com.sparta.hotsixproject.notification.entity.QNotification> notificationList = this.<com.sparta.hotsixproject.notification.entity.Notification, com.sparta.hotsixproject.notification.entity.QNotification>createList("notificationList", com.sparta.hotsixproject.notification.entity.Notification.class, com.sparta.hotsixproject.notification.entity.QNotification.class, PathInits.DIRECT2);
+
     public final ListPath<com.sparta.hotsixproject.side.entity.Side, com.sparta.hotsixproject.side.entity.QSide> sideList = this.<com.sparta.hotsixproject.side.entity.Side, com.sparta.hotsixproject.side.entity.QSide>createList("sideList", com.sparta.hotsixproject.side.entity.Side.class, com.sparta.hotsixproject.side.entity.QSide.class, PathInits.DIRECT2);
 
     public final com.sparta.hotsixproject.user.entity.QUser user;

--- a/src/main/generated/com/sparta/hotsixproject/notification/entity/QNotification.java
+++ b/src/main/generated/com/sparta/hotsixproject/notification/entity/QNotification.java
@@ -22,6 +22,8 @@ public class QNotification extends EntityPathBase<Notification> {
 
     public static final QNotification notification = new QNotification("notification");
 
+    public final com.sparta.hotsixproject.board.entity.QBoard board;
+
     public final StringPath detail = createString("detail");
 
     public final com.sparta.hotsixproject.user.entity.QUser editor;
@@ -50,6 +52,7 @@ public class QNotification extends EntityPathBase<Notification> {
 
     public QNotification(Class<? extends Notification> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
+        this.board = inits.isInitialized("board") ? new com.sparta.hotsixproject.board.entity.QBoard(forProperty("board"), inits.get("board")) : null;
         this.editor = inits.isInitialized("editor") ? new com.sparta.hotsixproject.user.entity.QUser(forProperty("editor")) : null;
     }
 

--- a/src/main/generated/com/sparta/hotsixproject/notification/entity/QNotification.java
+++ b/src/main/generated/com/sparta/hotsixproject/notification/entity/QNotification.java
@@ -22,8 +22,6 @@ public class QNotification extends EntityPathBase<Notification> {
 
     public static final QNotification notification = new QNotification("notification");
 
-    public final com.sparta.hotsixproject.board.entity.QBoard board;
-
     public final StringPath detail = createString("detail");
 
     public final com.sparta.hotsixproject.user.entity.QUser editor;
@@ -52,7 +50,6 @@ public class QNotification extends EntityPathBase<Notification> {
 
     public QNotification(Class<? extends Notification> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.board = inits.isInitialized("board") ? new com.sparta.hotsixproject.board.entity.QBoard(forProperty("board"), inits.get("board")) : null;
         this.editor = inits.isInitialized("editor") ? new com.sparta.hotsixproject.user.entity.QUser(forProperty("editor")) : null;
     }
 

--- a/src/main/java/com/sparta/hotsixproject/board/entity/Board.java
+++ b/src/main/java/com/sparta/hotsixproject/board/entity/Board.java
@@ -3,7 +3,6 @@ package com.sparta.hotsixproject.board.entity;
 import com.sparta.hotsixproject.board.dto.BoardRequestDto;
 import com.sparta.hotsixproject.boarduser.entity.BoardUser;
 import com.sparta.hotsixproject.label.entity.Label;
-import com.sparta.hotsixproject.notification.entity.Notification;
 import com.sparta.hotsixproject.side.entity.Side;
 import com.sparta.hotsixproject.user.entity.User;
 import jakarta.persistence.*;
@@ -11,7 +10,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.awt.*;
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -44,9 +42,6 @@ public class Board {
 
     @OneToMany(mappedBy = "board", orphanRemoval = true)
     private List<Label> labelList;
-
-    @OneToMany(mappedBy = "board", orphanRemoval = true)
-    private List<Notification> notificationList = new ArrayList<>();
 
     public Board(String name, String description, User user,Integer red, Integer green, Integer blue){
         this.name = name;

--- a/src/main/java/com/sparta/hotsixproject/board/entity/Board.java
+++ b/src/main/java/com/sparta/hotsixproject/board/entity/Board.java
@@ -3,6 +3,7 @@ package com.sparta.hotsixproject.board.entity;
 import com.sparta.hotsixproject.board.dto.BoardRequestDto;
 import com.sparta.hotsixproject.boarduser.entity.BoardUser;
 import com.sparta.hotsixproject.label.entity.Label;
+import com.sparta.hotsixproject.notification.entity.Notification;
 import com.sparta.hotsixproject.side.entity.Side;
 import com.sparta.hotsixproject.user.entity.User;
 import jakarta.persistence.*;
@@ -10,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.awt.*;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -42,6 +44,9 @@ public class Board {
 
     @OneToMany(mappedBy = "board", orphanRemoval = true)
     private List<Label> labelList;
+
+    @OneToMany(mappedBy = "board", orphanRemoval = true)
+    private List<Notification> notificationList = new ArrayList<>();
 
     public Board(String name, String description, User user,Integer red, Integer green, Integer blue){
         this.name = name;

--- a/src/main/java/com/sparta/hotsixproject/boarduser/repository/BoardUserRepository.java
+++ b/src/main/java/com/sparta/hotsixproject/boarduser/repository/BoardUserRepository.java
@@ -11,9 +11,6 @@ import java.util.Optional;
 
 @Repository
 public interface BoardUserRepository extends JpaRepository<BoardUser, Long> {
-    boolean existsByBoard_IdAndUser_Id(Long boardId, Long userId);
-    boolean existsByUser_Id(Long id);
-    BoardUser findByUser_Id(Long id);
     Optional<BoardUser> findByUser_EmailAndBoard_Id(String email, Long Id);
     List<BoardUser> findByBoard_Id(Long Id);
     List<BoardUser> findAllByUser(User user);

--- a/src/main/java/com/sparta/hotsixproject/boarduser/repository/BoardUserRepository.java
+++ b/src/main/java/com/sparta/hotsixproject/boarduser/repository/BoardUserRepository.java
@@ -11,6 +11,9 @@ import java.util.Optional;
 
 @Repository
 public interface BoardUserRepository extends JpaRepository<BoardUser, Long> {
+    boolean existsByBoard_IdAndUser_Id(Long boardId, Long userId);
+    boolean existsByUser_Id(Long id);
+    BoardUser findByUser_Id(Long id);
     Optional<BoardUser> findByUser_EmailAndBoard_Id(String email, Long Id);
     List<BoardUser> findByBoard_Id(Long Id);
     List<BoardUser> findAllByUser(User user);

--- a/src/main/java/com/sparta/hotsixproject/card/event/CardUpdateEventListener.java
+++ b/src/main/java/com/sparta/hotsixproject/card/event/CardUpdateEventListener.java
@@ -21,17 +21,17 @@ public class CardUpdateEventListener implements ApplicationListener<CardUpdateEv
         Card card = event.getCard();
         if (event.getOldName() != event.getNewName()) {
             log.info("Update Card Name");
-            Notification notification = new Notification(CARD_NAME_UPDATED, card.getName(), card.getModifiedAt(), event.getUser(), card.getSide().getBoard());
+            Notification notification = new Notification(CARD_NAME_UPDATED, card.getName(), card.getModifiedAt(), event.getUser());
             notificationService.saveNotification(notification);
         }
         else if (event.getOldDescription() != event.getNewDescription()) {
             log.info("Update Card Description");
-            Notification notification = new Notification(CARD_DESC_UPDATED, card.getDescription(), card.getModifiedAt(), event.getUser(), card.getSide().getBoard());
+            Notification notification = new Notification(CARD_DESC_UPDATED, card.getDescription(), card.getModifiedAt(), event.getUser());
             notificationService.saveNotification(notification);
         }
         else {
             log.info("Update Card Color");
-            Notification notification = new Notification(CARD_COLOR_UPDATED, card.getColor(), card.getModifiedAt(), event.getUser(), card.getSide().getBoard());
+            Notification notification = new Notification(CARD_COLOR_UPDATED, card.getColor(), card.getModifiedAt(), event.getUser());
             notificationService.saveNotification(notification);
         }
     }

--- a/src/main/java/com/sparta/hotsixproject/card/event/CardUpdateEventListener.java
+++ b/src/main/java/com/sparta/hotsixproject/card/event/CardUpdateEventListener.java
@@ -21,17 +21,17 @@ public class CardUpdateEventListener implements ApplicationListener<CardUpdateEv
         Card card = event.getCard();
         if (event.getOldName() != event.getNewName()) {
             log.info("Update Card Name");
-            Notification notification = new Notification(CARD_NAME_UPDATED, card.getName(), card.getModifiedAt(), event.getUser());
+            Notification notification = new Notification(CARD_NAME_UPDATED, card.getName(), card.getModifiedAt(), event.getUser(), card.getSide().getBoard());
             notificationService.saveNotification(notification);
         }
         else if (event.getOldDescription() != event.getNewDescription()) {
             log.info("Update Card Description");
-            Notification notification = new Notification(CARD_DESC_UPDATED, card.getDescription(), card.getModifiedAt(), event.getUser());
+            Notification notification = new Notification(CARD_DESC_UPDATED, card.getDescription(), card.getModifiedAt(), event.getUser(), card.getSide().getBoard());
             notificationService.saveNotification(notification);
         }
         else {
             log.info("Update Card Color");
-            Notification notification = new Notification(CARD_COLOR_UPDATED, card.getColor(), card.getModifiedAt(), event.getUser());
+            Notification notification = new Notification(CARD_COLOR_UPDATED, card.getColor(), card.getModifiedAt(), event.getUser(), card.getSide().getBoard());
             notificationService.saveNotification(notification);
         }
     }

--- a/src/main/java/com/sparta/hotsixproject/card/event/EventPublisher.java
+++ b/src/main/java/com/sparta/hotsixproject/card/event/EventPublisher.java
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Component;
 
 @Slf4j(topic = "비동기 처리를 위한 Custom EventPublisher")
 @Component
-// @EnableAsync
+@EnableAsync
 @RequiredArgsConstructor
 public class EventPublisher {
     public final ApplicationEventPublisher eventPublisher;
 
-    // @Async
+    @Async
     public void publishCardUpdatedEvent(User user, Card card, String oldName, String newName,
                                         String oldDescription, String newDescription,
                                         String oldColor, String newColor) {

--- a/src/main/java/com/sparta/hotsixproject/card/event/EventPublisher.java
+++ b/src/main/java/com/sparta/hotsixproject/card/event/EventPublisher.java
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Component;
 
 @Slf4j(topic = "비동기 처리를 위한 Custom EventPublisher")
 @Component
-@EnableAsync
+// @EnableAsync
 @RequiredArgsConstructor
 public class EventPublisher {
     public final ApplicationEventPublisher eventPublisher;
 
-    @Async
+    // @Async
     public void publishCardUpdatedEvent(User user, Card card, String oldName, String newName,
                                         String oldDescription, String newDescription,
                                         String oldColor, String newColor) {

--- a/src/main/java/com/sparta/hotsixproject/notification/controller/NotificationController.java
+++ b/src/main/java/com/sparta/hotsixproject/notification/controller/NotificationController.java
@@ -1,13 +1,10 @@
 package com.sparta.hotsixproject.notification.controller;
 
-import com.sparta.hotsixproject.common.security.UserDetailsImpl;
 import com.sparta.hotsixproject.notification.dto.NotificationResponseDto;
 import com.sparta.hotsixproject.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,9 +16,9 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
-    @GetMapping("/notifications/{boardId}")
+    @GetMapping("/notifications")
     @Operation(summary = "알림 전체 조회")
-    public List<NotificationResponseDto> getNotifications(@PathVariable Long boardId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return notificationService.getNotifications(boardId, userDetails.getUser());
+    public List<NotificationResponseDto> getNotifications() {
+        return notificationService.getNotifications();
     }
 }

--- a/src/main/java/com/sparta/hotsixproject/notification/controller/NotificationController.java
+++ b/src/main/java/com/sparta/hotsixproject/notification/controller/NotificationController.java
@@ -1,10 +1,13 @@
 package com.sparta.hotsixproject.notification.controller;
 
+import com.sparta.hotsixproject.common.security.UserDetailsImpl;
 import com.sparta.hotsixproject.notification.dto.NotificationResponseDto;
 import com.sparta.hotsixproject.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,9 +19,9 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
-    @GetMapping("/notifications")
+    @GetMapping("/notifications/{boardId}")
     @Operation(summary = "알림 전체 조회")
-    public List<NotificationResponseDto> getNotifications() {
-        return notificationService.getNotifications();
+    public List<NotificationResponseDto> getNotifications(@PathVariable Long boardId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return notificationService.getNotifications(boardId, userDetails.getUser());
     }
 }

--- a/src/main/java/com/sparta/hotsixproject/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/sparta/hotsixproject/notification/dto/NotificationResponseDto.java
@@ -12,13 +12,11 @@ public class NotificationResponseDto {
     private NotificationTitle title;
     private String detail;
     private Long editedTime;
-    private String editorName;
 
     public NotificationResponseDto(Notification notification) {
         this.notificationId = notification.getId();
         this.title = notification.getTitle();
         this.detail = notification.getDetail();
         this.editedTime = Duration.parse(notification.getTimeSinceModified()).toMinutes();
-        this.editorName = notification.getEditor().getNickname();
     }
 }

--- a/src/main/java/com/sparta/hotsixproject/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/sparta/hotsixproject/notification/dto/NotificationResponseDto.java
@@ -12,11 +12,13 @@ public class NotificationResponseDto {
     private NotificationTitle title;
     private String detail;
     private Long editedTime;
+    private String editorName;
 
     public NotificationResponseDto(Notification notification) {
         this.notificationId = notification.getId();
         this.title = notification.getTitle();
         this.detail = notification.getDetail();
         this.editedTime = Duration.parse(notification.getTimeSinceModified()).toMinutes();
+        this.editorName = notification.getEditor().getNickname();
     }
 }

--- a/src/main/java/com/sparta/hotsixproject/notification/entity/Notification.java
+++ b/src/main/java/com/sparta/hotsixproject/notification/entity/Notification.java
@@ -1,6 +1,5 @@
 package com.sparta.hotsixproject.notification.entity;
 
-import com.sparta.hotsixproject.board.entity.Board;
 import com.sparta.hotsixproject.notification.NotificationTitle;
 import com.sparta.hotsixproject.user.entity.User;
 import jakarta.persistence.*;
@@ -39,16 +38,10 @@ public class Notification {
     @JoinColumn(nullable = false)
     private User editor;
 
-    // 알림이 속한 board
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
-    private Board board;
-
-    public Notification(NotificationTitle title, String detail, LocalDateTime modifiedAt, User editor, Board board) {
+    public Notification(NotificationTitle title, String detail, LocalDateTime modifiedAt, User editor) {
         this.title = title;
         this.detail = detail;
         this.timeSinceModified = Duration.between(modifiedAt, LocalDateTime.now()).toString();
         this.editor = editor;
-        this.board = board;
     }
 }

--- a/src/main/java/com/sparta/hotsixproject/notification/entity/Notification.java
+++ b/src/main/java/com/sparta/hotsixproject/notification/entity/Notification.java
@@ -1,5 +1,6 @@
 package com.sparta.hotsixproject.notification.entity;
 
+import com.sparta.hotsixproject.board.entity.Board;
 import com.sparta.hotsixproject.notification.NotificationTitle;
 import com.sparta.hotsixproject.user.entity.User;
 import jakarta.persistence.*;
@@ -38,10 +39,16 @@ public class Notification {
     @JoinColumn(nullable = false)
     private User editor;
 
-    public Notification(NotificationTitle title, String detail, LocalDateTime modifiedAt, User editor) {
+    // 알림이 속한 board
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Board board;
+
+    public Notification(NotificationTitle title, String detail, LocalDateTime modifiedAt, User editor, Board board) {
         this.title = title;
         this.detail = detail;
         this.timeSinceModified = Duration.between(modifiedAt, LocalDateTime.now()).toString();
         this.editor = editor;
+        this.board = board;
     }
 }

--- a/src/main/java/com/sparta/hotsixproject/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sparta/hotsixproject/notification/repository/NotificationRepository.java
@@ -3,8 +3,5 @@ package com.sparta.hotsixproject.notification.repository;
 import com.sparta.hotsixproject.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    List<Notification> findByBoard_Id(Long id);
 }

--- a/src/main/java/com/sparta/hotsixproject/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sparta/hotsixproject/notification/repository/NotificationRepository.java
@@ -3,5 +3,8 @@ package com.sparta.hotsixproject.notification.repository;
 import com.sparta.hotsixproject.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByBoard_Id(Long id);
 }

--- a/src/main/java/com/sparta/hotsixproject/notification/service/NotificationService.java
+++ b/src/main/java/com/sparta/hotsixproject/notification/service/NotificationService.java
@@ -1,14 +1,11 @@
 package com.sparta.hotsixproject.notification.service;
 
-import com.sparta.hotsixproject.boarduser.entity.BoardUser;
-import com.sparta.hotsixproject.boarduser.repository.BoardUserRepository;
 import com.sparta.hotsixproject.card.entity.Card;
 import com.sparta.hotsixproject.card.event.CardUpdateEvent;
 import com.sparta.hotsixproject.common.advice.ApiResponseDto;
 import com.sparta.hotsixproject.notification.dto.NotificationResponseDto;
 import com.sparta.hotsixproject.notification.entity.Notification;
 import com.sparta.hotsixproject.notification.repository.NotificationRepository;
-import com.sparta.hotsixproject.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +20,6 @@ import static com.sparta.hotsixproject.notification.NotificationTitle.CARD_NAME_
 @RequiredArgsConstructor
 public class NotificationService {
     private final NotificationRepository notificationRepository;
-    private final BoardUserRepository boardUserRepository;
 
     @Transactional
     public void saveNotification(Notification notification) {
@@ -31,12 +27,7 @@ public class NotificationService {
     }
 
     @Transactional(readOnly = true)
-    public List<NotificationResponseDto> getNotifications(Long boardId, User user) {
-        if (boardUserRepository.existsByBoard_IdAndUser_Id(boardId, user.getId())) {
-            return notificationRepository.findByBoard_Id(boardId).stream().map(NotificationResponseDto::new).toList();
-        }
-        else {
-            return null;
-        }
+    public List<NotificationResponseDto> getNotifications() {
+        return notificationRepository.findAll().stream().map(NotificationResponseDto::new).toList();
     }
 }

--- a/src/main/java/com/sparta/hotsixproject/notification/service/NotificationService.java
+++ b/src/main/java/com/sparta/hotsixproject/notification/service/NotificationService.java
@@ -1,11 +1,14 @@
 package com.sparta.hotsixproject.notification.service;
 
+import com.sparta.hotsixproject.boarduser.entity.BoardUser;
+import com.sparta.hotsixproject.boarduser.repository.BoardUserRepository;
 import com.sparta.hotsixproject.card.entity.Card;
 import com.sparta.hotsixproject.card.event.CardUpdateEvent;
 import com.sparta.hotsixproject.common.advice.ApiResponseDto;
 import com.sparta.hotsixproject.notification.dto.NotificationResponseDto;
 import com.sparta.hotsixproject.notification.entity.Notification;
 import com.sparta.hotsixproject.notification.repository.NotificationRepository;
+import com.sparta.hotsixproject.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +23,7 @@ import static com.sparta.hotsixproject.notification.NotificationTitle.CARD_NAME_
 @RequiredArgsConstructor
 public class NotificationService {
     private final NotificationRepository notificationRepository;
+    private final BoardUserRepository boardUserRepository;
 
     @Transactional
     public void saveNotification(Notification notification) {
@@ -27,7 +31,12 @@ public class NotificationService {
     }
 
     @Transactional(readOnly = true)
-    public List<NotificationResponseDto> getNotifications() {
-        return notificationRepository.findAll().stream().map(NotificationResponseDto::new).toList();
+    public List<NotificationResponseDto> getNotifications(Long boardId, User user) {
+        if (boardUserRepository.existsByBoard_IdAndUser_Id(boardId, user.getId())) {
+            return notificationRepository.findByBoard_Id(boardId).stream().map(NotificationResponseDto::new).toList();
+        }
+        else {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
# 변경점
## 알람 전체 조회 api 주소
![image](https://github.com/spring-b-hotsix/hotsix-project/assets/78305720/3bbeca14-70f8-435c-97cc-43d0fd5cd57c)

## 1번 보드에 속한 유저가 보는 1번 보드에 대한 전체 알람
![image](https://github.com/spring-b-hotsix/hotsix-project/assets/78305720/3437d858-d6c7-4415-a3ed-0376937ec23f)

## 2번 보드에 속한 유저가 보는 2번 보드에 대한 전체 알람
![image](https://github.com/spring-b-hotsix/hotsix-project/assets/78305720/e5218cdf-ed50-4b90-ab07-62ad9176132e)

##  보드에 속하지 않은 유저가 알람을 조회 했을 때는 알람을 응답 받지 못합니다.
![image](https://github.com/spring-b-hotsix/hotsix-project/assets/78305720/566056d8-b79f-4882-ad90-6e9d95edd575)

### 각자 보드에 대한 알람이 다르게 조회 되도록 수정했습니다. 마무리도 화이팅입니다 다들!