### PR TITLE
[Fix] 프론트엔드 카드 상세화면 X클릭시 보드로 돌아가도록 설정

### DIFF
--- a/src/main/resources/templates/card.html
+++ b/src/main/resources/templates/card.html
@@ -193,7 +193,7 @@
                         in list</h6><h6 th:text="${card.body.sideName}"></h6>
                 </div>
             </div>
-            <button type="button" class="btn-close ms-auto" th:onclick="|window.location.href='/boards/'+${boardId}'/cards/'+${cardId}|" aria-label="Close"
+            <button type="button" class="btn-close ms-auto" th:onclick="|window.location.href='/boards/'+${boardId}|" aria-label="Close"
                     style="margin-right: 30px;"></button>
             <div>
             </div>


### PR DESCRIPTION
프론트엔드 카드 상세화면 X클릭시 보드로 돌아가도록 설정 하여 pr을 요청합니다